### PR TITLE
Updating wherex for rails 31 compat. also bumping rails for test mode.

### DIFF
--- a/glyph_filter.gemspec
+++ b/glyph_filter.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   s.add_dependency "railties", ">= 3.0.0"
-  s.add_dependency "wherex", "~> 1.0.1"
+  s.add_dependency "wherex", "~> 1.0.7"
   s.add_development_dependency "capybara", ">= 0.4.0"
   s.add_development_dependency 'rspec', ['>= 0']
   s.add_development_dependency 'rspec-rails', ['>= 0']
   s.add_development_dependency 'database_cleaner', ['>= 0']
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rails", "~> 3.0.0"
+  s.add_development_dependency "rails", "~> 3.0"
   s.add_development_dependency "geminabox"
   s.add_development_dependency 'rr', ['>= 0']
   


### PR DESCRIPTION
Latest version of wherex fixes issues with rails 3.1/3.2 compatability. Fixes #5
