### PR TITLE
Fix two deprecation warnings for rails 3.2.

### DIFF
--- a/lib/glyph_filter/helpers/action_view_extension.rb
+++ b/lib/glyph_filter/helpers/action_view_extension.rb
@@ -3,18 +3,16 @@ require File.join(File.dirname(__FILE__), 'filter_section')
 module GlyphFilter
   module ActionViewExtension
     extend ::ActiveSupport::Concern
-    module InstanceMethods
-      def glyph_filter(options = {}, &block)
-        options.reverse_merge!(
-          :param_name => GlyphFilter.config.param_name, 
-          :left_over => GlyphFilter.config.left_over, 
-          :excluded_params => [:page], 
-          :glyphs => GlyphFilter.config.glyphs, 
-          :current_section => (params[GlyphFilter.config.param_name] ? params[GlyphFilter.config.param_name] : nil)
-        )
-        filter_section = GlyphFilter::Helpers::FilterSection.new(self, options)
-        filter_section.to_s
-      end
+    def glyph_filter(options = {}, &block)
+      options.reverse_merge!(
+        :param_name => GlyphFilter.config.param_name, 
+        :left_over => GlyphFilter.config.left_over, 
+        :excluded_params => [:page], 
+        :glyphs => GlyphFilter.config.glyphs, 
+        :current_section => (params[GlyphFilter.config.param_name] ? params[GlyphFilter.config.param_name] : nil)
+      )
+      filter_section = GlyphFilter::Helpers::FilterSection.new(self, options)
+      filter_section.to_s
     end
   end
 end

--- a/lib/glyph_filter/models/active_record_extension.rb
+++ b/lib/glyph_filter/models/active_record_extension.rb
@@ -5,9 +5,12 @@ module GlyphFilter
     extend ActiveSupport::Concern
     included do
       # Future subclasses will pick up the model extension
-      def self.inherited(kls) #:nodoc:
-        super
-        kls.send(:include, GlyphFilter::ActiveRecordModelExtension) if kls.superclass == ActiveRecord::Base
+      class << self
+        def inherited_with_glyph_filter(kls) #:nodoc:
+          inherited_without_glyph_filter kls
+          kls.send(:include, GlyphFilter::ActiveRecordModelExtension) if kls.superclass == ActiveRecord::Base
+        end
+        alias_method_chain :inherited, :glyph_filter
       end
 
       # Existing subclasses pick up the model extension as well


### PR DESCRIPTION
Fixes #4.  Also addresses the deprecation warning:

```
DEPRECATION WARNING: It looks like something (probably a gem/plugin) is overriding the ActiveRecord::Base.inherited method. It is important that this hook executes so that your models are set up correctly. A workaround has been added to stop this causing an error in 3.2, but future versions will simply not work if the hook is overridden. If you are using Kaminari, please upgrade as it is known to have had this problem.

The following may help track down the problem: ["/Users/sean/eventrobot_source/glyph_filter/lib/glyph_filter/models/active_record_extension.rb", 8]
```
