### PR TITLE
Update for rails5 compatibility

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+glyph_filter

--- a/.ruby-version
+++ b/.ruby-version
@@ -1,0 +1,1 @@
+default

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,6 +1,0 @@
-rvm use ruby-1.9.3-p125@glyph_filter --create
-if ! command -v bundle ; then
-  gem install bundler
-  bundle install
-fi
-

--- a/glyph_filter.gemspec
+++ b/glyph_filter.gemspec
@@ -5,8 +5,8 @@ require "glyph_filter/version"
 Gem::Specification.new do |s|
   s.name        = "glyph_filter"
   s.version     = GlyphFilter::VERSION
-  s.authors     = ["Sean Cashin"]
-  s.email       = ["scashin133@gmail.com"]
+  s.authors     = ["Sean Cashin", "developers@socialcast.com"]
+  s.email       = ["developers@socialcast.com"]
   s.homepage    = "https://github.com/socialcast/glyph_filter"
   s.summary     = %q{Filter glyphs in rails}
   s.description = %q{Add ability to filter ActiveRecord models by glyph and display a filter section in your views}

--- a/glyph_filter.gemspec
+++ b/glyph_filter.gemspec
@@ -27,7 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner', ['>= 0']
   s.add_development_dependency "rails", ">= 4"
   s.add_development_dependency "geminabox"
-  s.add_development_dependency 'rr', ['>= 0']
   s.add_development_dependency "sqlite3"
-
 end

--- a/glyph_filter.gemspec
+++ b/glyph_filter.gemspec
@@ -19,14 +19,13 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_dependency "railties", ">= 3.0.0"
-  s.add_dependency "wherex", "~> 1.0.7"
+  s.add_dependency "railties", ">= 4.0.0"
   s.add_development_dependency "capybara", ">= 0.4.0"
   s.add_development_dependency "haml", ['>= 0']
   s.add_development_dependency 'rspec', ['>= 0']
   s.add_development_dependency 'rspec-rails', ['>= 0']
   s.add_development_dependency 'database_cleaner', ['>= 0']
-  s.add_development_dependency "rails", "~> 3.2"
+  s.add_development_dependency "rails", ">= 4"
   s.add_development_dependency "geminabox"
   s.add_development_dependency 'rr', ['>= 0']
   s.add_development_dependency "sqlite3"

--- a/lib/glyph_filter/helpers/tags.rb
+++ b/lib/glyph_filter/helpers/tags.rb
@@ -36,6 +36,9 @@ module GlyphFilter::Helpers
       else
         @params.merge(@options[:param_name] => filter_section)
       end
+      these_params[:only_path] = true
+      these_params.permit! if these_params.respond_to?(:permit!)
+
       @template.url_for these_params
     end
   end

--- a/lib/glyph_filter/models/active_record_extension.rb
+++ b/lib/glyph_filter/models/active_record_extension.rb
@@ -29,11 +29,14 @@ module GlyphFilter
     included do
       # Future subclasses will pick up the model extension
       class << self
-        def inherited_with_glyph_filter(kls) #:nodoc:
-          inherited_without_glyph_filter kls
-          kls.send(:include, GlyphFilter::ActiveRecordModelExtension) if kls.superclass == ActiveRecord::Base
-        end
-        alias_method_chain :inherited, :glyph_filter
+        prepend(
+          Module.new do
+            def inherited(kls) #:nodoc:
+              super
+              kls.send(:include, GlyphFilter::ActiveRecordModelExtension) if kls.superclass == ActiveRecord::Base
+            end
+          end
+        )
       end
 
       # Existing subclasses pick up the model extension as well

--- a/lib/glyph_filter/models/active_record_model_extension.rb
+++ b/lib/glyph_filter/models/active_record_model_extension.rb
@@ -30,7 +30,7 @@ module GlyphFilter
         if glyph.blank?
           where({})
         elsif glyph == GlyphFilter.config.left_over
-          where(column => /^[^#{(GlyphFilter.config.glyphs + GlyphFilter.config.glyphs.map(&:downcase)).uniq.join("|")}]/)
+          where("#{column} REGEXP ?", "^[^#{(GlyphFilter.config.glyphs + GlyphFilter.config.glyphs.map(&:downcase)).uniq.join("|")}]")
         else
           a_table = self.arel_table
           where(a_table[column.to_sym].matches(glyph + "%"))

--- a/lib/glyph_filter/railtie.rb
+++ b/lib/glyph_filter/railtie.rb
@@ -22,7 +22,6 @@ IN THE SOFTWARE.
 =end
 
 require 'rails'
-require 'wherex'
 
 require 'glyph_filter/config'
 require 'glyph_filter/helpers/action_view_extension'

--- a/lib/glyph_filter/version.rb
+++ b/lib/glyph_filter/version.rb
@@ -22,5 +22,5 @@ IN THE SOFTWARE.
 =end
 
 module GlyphFilter
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -24,11 +24,11 @@ IN THE SOFTWARE.
 require 'spec_helper'
 
 describe GlyphFilter::Configuration do
-  subject { GlyphFilter.config }
+  let(:glyph_filter_config) { GlyphFilter.config }
   describe 'glyphs' do
     context 'by default' do
       describe '#glyphs' do
-        subject { super().glyphs }
+        subject { glyph_filter_config.glyphs }
         it { is_expected.to eq(("A".."Z").to_a) }
       end
     end
@@ -38,7 +38,7 @@ describe GlyphFilter::Configuration do
       end
 
       describe '#glyphs' do
-        subject { super().glyphs }
+        subject { glyph_filter_config.glyphs }
         it { is_expected.to eq([1,2,3]) }
       end
       after do
@@ -49,7 +49,7 @@ describe GlyphFilter::Configuration do
   describe 'param_name' do
     context 'by default' do
       describe '#param_name' do
-        subject { super().param_name }
+        subject { glyph_filter_config.param_name }
         it { is_expected.to eq(:glyph) }
       end
     end
@@ -58,7 +58,7 @@ describe GlyphFilter::Configuration do
   describe 'left_over' do
     context 'by default' do
       describe '#left_over' do
-        subject { super().left_over }
+        subject { glyph_filter_config.left_over }
         it { is_expected.to eq("?") }
       end
     end

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -26,41 +26,27 @@ require 'spec_helper'
 describe GlyphFilter::Configuration do
   let(:glyph_filter_config) { GlyphFilter.config }
   describe 'glyphs' do
+    subject { glyph_filter_config.glyphs }
     context 'by default' do
-      describe '#glyphs' do
-        subject { glyph_filter_config.glyphs }
-        it { is_expected.to eq(("A".."Z").to_a) }
-      end
+      it { is_expected.to eq(("A".."Z").to_a) }
     end
     context 'configured via config block' do
       before do
         GlyphFilter.configure {|c| c.glyphs = [1,2,3]}
       end
-
-      describe '#glyphs' do
-        subject { glyph_filter_config.glyphs }
-        it { is_expected.to eq([1,2,3]) }
-      end
+      it { is_expected.to eq([1,2,3]) }
       after do
         GlyphFilter.configure {|c| c.glyphs = ("A".."Z").to_a}
       end
     end
   end
   describe 'param_name' do
-    context 'by default' do
-      describe '#param_name' do
-        subject { glyph_filter_config.param_name }
-        it { is_expected.to eq(:glyph) }
-      end
-    end
+    subject { glyph_filter_config.param_name }
+    it { is_expected.to eq(:glyph) }
   end
 
   describe 'left_over' do
-    context 'by default' do
-      describe '#left_over' do
-        subject { glyph_filter_config.left_over }
-        it { is_expected.to eq("?") }
-      end
-    end
+    subject { glyph_filter_config.left_over }
+    it { is_expected.to eq("?") }
   end
 end

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -27,13 +27,20 @@ describe GlyphFilter::Configuration do
   subject { GlyphFilter.config }
   describe 'glyphs' do
     context 'by default' do
-      its(:glyphs) { should == (("A".."Z").to_a) }
+      describe '#glyphs' do
+        subject { super().glyphs }
+        it { is_expected.to eq(("A".."Z").to_a) }
+      end
     end
     context 'configured via config block' do
       before do
         GlyphFilter.configure {|c| c.glyphs = [1,2,3]}
       end
-      its(:glyphs) { should == [1,2,3] }
+
+      describe '#glyphs' do
+        subject { super().glyphs }
+        it { is_expected.to eq([1,2,3]) }
+      end
       after do
         GlyphFilter.configure {|c| c.glyphs = ("A".."Z").to_a}
       end
@@ -41,13 +48,19 @@ describe GlyphFilter::Configuration do
   end
   describe 'param_name' do
     context 'by default' do
-      its(:param_name) { should == :glyph }
+      describe '#param_name' do
+        subject { super().param_name }
+        it { is_expected.to eq(:glyph) }
+      end
     end
   end
 
   describe 'left_over' do
     context 'by default' do
-      its(:left_over) { should == "?" }
+      describe '#left_over' do
+        subject { super().left_over }
+        it { is_expected.to eq("?") }
+      end
     end
   end
 end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -26,8 +26,7 @@ require 'action_controller/railtie'
 require 'action_view/railtie'
 
 # database
-ActiveRecord::Base.configurations = {'test' => {:adapter => 'sqlite3', :database => ':memory:'}}
-ActiveRecord::Base.establish_connection('test')
+ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
 
 # config
 app = Class.new(Rails::Application)

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -23,69 +23,69 @@ IN THE SOFTWARE.
 
 require 'spec_helper'
 
-describe 'GlyphFilter::ActionViewExtension' do
+describe 'GlyphFilter::ActionViewExtension', :type => :helper do
   describe '#glyph_filter' do
     before do
       @params = {:controller => 'users', :action => 'index'}
     end
     subject { helper.glyph_filter :params => @params }
-    it { should be_a String }
+    it { is_expected.to be_a String }
     context 'params with page' do
       before do
         @params = @params.merge(:page => '1')
       end
       context 'default behaviour' do
         subject { helper.glyph_filter(:params => @params) }
-        it { should_not match /page\=1/}
+        it { is_expected.not_to match /page\=1/}
       end
       context 'override excluded_params' do
         subject { helper.glyph_filter(:params => @params, :excluded_params => [:nothing]) }
-        it { should match /page\=1/}
+        it { is_expected.to match /page\=1/}
       end
     end
     context ':param_name' do
       context 'default behaviour' do
         subject { helper.glyph_filter(:params => @params) }
-        it { should match /glyph\=A/}
+        it { is_expected.to match /glyph\=A/}
       end
       context 'override :param_name' do
         subject { helper.glyph_filter(:params => @params, :param_name => :nothing) }
-        it { should match /nothing\=A/}
+        it { is_expected.to match /nothing\=A/}
       end
     end
     context ':left_over' do
       context 'default behaviour' do
         subject { helper.glyph_filter(:params => @params) }
-        it { should match /glyph\=\%3F/}
+        it { is_expected.to match /glyph\=\%3F/}
       end
       context 'override :left_over' do
         subject { helper.glyph_filter(:params => @params, :left_over => 'nothing') }
-        it { should match /glyph\=nothing/}
+        it { is_expected.to match /glyph\=nothing/}
       end
     end
     context ':glyphs' do
       context 'default behaviour' do
         subject { helper.glyph_filter(:params => @params) }
         ("A".."Z").to_a.each do |glyph|
-          it { should match /glyph\=#{glyph}/}
+          it { is_expected.to match /glyph\=#{glyph}/}
         end
       end
       context 'override :glyphs' do
         subject { helper.glyph_filter(:params => @params, :glyphs => ['a']) }
-        it { should match /glyph\=a/}
+        it { is_expected.to match /glyph\=a/}
         ("A".."Z").to_a.each do |glyph|
-          it { should_not match /glyph\=#{glyph}/}
+          it { is_expected.not_to match /glyph\=#{glyph}/}
         end
       end
     end
     context ':current_section' do
       context 'default behaviour' do
         subject { helper.glyph_filter(:params => @params) }
-        it { should match /\<span\sclass\=\"all\scurrent\"\>\s*ALL\s*\<\/span\>/}
+        it { is_expected.to match /\<span\sclass\=\"all\scurrent\"\>\s*ALL\s*\<\/span\>/}
       end
       context 'override :current_section' do
         subject { helper.glyph_filter(:params => @params, :current_section => 'A') }
-        it { should match /\<span\sclass\=\"glyph\scurrent\"\>\s*A\s*\<\/span\>/}
+        it { is_expected.to match /\<span\sclass\=\"glyph\scurrent\"\>\s*A\s*\<\/span\>/}
       end
     end
 

--- a/spec/helpers/tags_spec.rb
+++ b/spec/helpers/tags_spec.rb
@@ -68,30 +68,21 @@ describe 'GlyphFilter::Helpers', :type => :helper do
       before do
         @template = double(:params => { :controller => "users", :action => 'index' })
       end
-      subject { GlyphFilter::Helpers::Glyph.new(@template, :glyph => 'A') }
-
-      describe '#section_value' do
-        subject { super().section_value }
-        it { is_expected.to eq('A') }
-      end
+      let(:glyph) { GlyphFilter::Helpers::Glyph.new(@template, :glyph => 'A') }
+      subject { glyph.section_value }
+      it { is_expected.to eq('A') }
     end
     describe '#url' do
-      subject { GlyphFilter::Helpers::Glyph.new(helper, :params => {"controller" => 'users', "action" => 'index'}, :glyph => 'A', :param_name => :glyph) }
-
-      describe '#url' do
-        subject { super().url }
-        it { is_expected.to eq("/users?glyph=A")}
-      end
+      let(:glyph) { GlyphFilter::Helpers::Glyph.new(helper, :params => {"controller" => 'users', "action" => 'index'}, :glyph => 'A', :param_name => :glyph) }
+      subject { glyph.url }
+      it { is_expected.to eq("/users?glyph=A")}
     end
   end
   describe 'All' do
     describe '#url' do
-      subject { GlyphFilter::Helpers::All.new(helper, :params => {"controller" => 'users', "action" => 'index', "glyph" => 'A'}, :param_name => :glyph) }
-
-      describe '#url' do
-        subject { super().url }
-        it { is_expected.to eq("/users")}
-      end
+      let(:glyph) { GlyphFilter::Helpers::All.new(helper, :params => {"controller" => 'users', "action" => 'index', "glyph" => 'A'}, :param_name => :glyph) }
+      subject { glyph.url }
+      it { is_expected.to eq("/users")}
     end
   end
 end

--- a/spec/helpers/tags_spec.rb
+++ b/spec/helpers/tags_spec.rb
@@ -23,75 +23,75 @@ IN THE SOFTWARE.
 
 require 'spec_helper'
 
-describe 'GlyphFilter::Helpers' do
+describe 'GlyphFilter::Helpers', :type => :helper do
   describe 'Tag' do
     describe '#initialize' do
       context 'no options' do
         before do
-          stub(@template = Object.new) do
-            params { {:controller => "users", :action => 'index'} }
-          end
+          @template = double(:params => { :controller => "users", :action => 'index' })
         end
         subject { GlyphFilter::Helpers::Tag.new(@template).instance_variable_get('@params') }
-        it { should == {:controller => "users", :action => 'index'} }
+        it { is_expected.to eq({:controller => "users", :action => 'index'}) }
       end
       context 'excluded_params of [page]' do
         before do
-          stub(@template = Object.new) do
-            params { {:controller => "users", :action => 'index', :page => '1'} }
-          end
+          @template = double(:params => { :controller => "users", :action => 'index', :page => '1' })
         end
         subject { GlyphFilter::Helpers::Tag.new(@template, :excluded_params => [:page]).instance_variable_get('@params') }
-        it { should == {:controller => "users", :action => 'index'} }
+        it { is_expected.to eq({:controller => "users", :action => 'index'}) }
       end
       context 'excluded_params of page' do
         before do
-          stub(@template = Object.new) do
-            params { {:controller => "users", :action => 'index', :page => '1'} }
-          end
+          @template = double(:params => { :controller => "users", :action => 'index', :page => '1' })
         end
         subject { GlyphFilter::Helpers::Tag.new(@template, :excluded_params => :page).instance_variable_get('@params') }
-        it { should == {:controller => "users", :action => 'index'} }
+        it { is_expected.to eq({:controller => "users", :action => 'index'}) }
       end
       context 'params of page' do
         before do
-          stub(@template = Object.new) do
-            params { {:controller => "users", :action => 'index'} }
-          end
+          @template = double(:params => { :controller => "users", :action => 'index' })
         end
         subject { GlyphFilter::Helpers::Tag.new(@template, :params => {:page => '1'}).instance_variable_get('@params') }
-        it { should == {:controller => "users", :action => 'index', :page => '1'} }
+        it { is_expected.to eq({:controller => "users", :action => 'index', :page => '1'}) }
       end
       context 'params of page and excluded_params of page' do
         before do
-          stub(@template = Object.new) do
-            params { {:controller => "users", :action => 'index'} }
-          end
+          @template = double(:params => { :controller => "users", :action => 'index' })
         end
         subject { GlyphFilter::Helpers::Tag.new(@template, :params => {:page => '1'}, :excluded_params => :page).instance_variable_get('@params') }
-        it { should == {:controller => "users", :action => 'index'} }
+        it { is_expected.to eq({:controller => "users", :action => 'index'}) }
       end
     end
   end
   describe 'Glyph' do
     describe '#section_value' do
       before do
-        stub(@template = Object.new) do
-          params { {:controller => "users", :action => 'index'} }
-        end
+        @template = double(:params => { :controller => "users", :action => 'index' })
       end
       subject { GlyphFilter::Helpers::Glyph.new(@template, :glyph => 'A') }
-      its(:section_value) { should == 'A' }
+
+      describe '#section_value' do
+        subject { super().section_value }
+        it { is_expected.to eq('A') }
+      end
     end
     describe '#url' do
       subject { GlyphFilter::Helpers::Glyph.new(helper, :params => {"controller" => 'users', "action" => 'index'}, :glyph => 'A', :param_name => :glyph) }
-      its(:url) { should == "/users?glyph=A"}
+
+      describe '#url' do
+        subject { super().url }
+        it { is_expected.to eq("/users?glyph=A")}
+      end
     end
   end
   describe 'All' do
     describe '#url' do
       subject { GlyphFilter::Helpers::All.new(helper, :params => {"controller" => 'users', "action" => 'index', "glyph" => 'A'}, :param_name => :glyph) }
-      its(:url) { should == "/users"}
+
+      describe '#url' do
+        subject { super().url }
+        it { is_expected.to eq("/users")}
+      end
     end
   end
 end

--- a/spec/models/scopes_spec.rb
+++ b/spec/models/scopes_spec.rb
@@ -23,7 +23,7 @@ IN THE SOFTWARE.
 
 require 'spec_helper'
 
-describe GlyphFilter::ActiveRecordModelExtension do
+describe GlyphFilter::ActiveRecordModelExtension, :type => :model do
   before :all do
     (['@'] + ("A".."Z").to_a).each {|character| User.create! :name => "#{character}user"}
   end
@@ -31,23 +31,59 @@ describe GlyphFilter::ActiveRecordModelExtension do
     describe '#glyph_filter' do
       context 'glyph_filter name, A' do
         subject { User.glyph_filter(:name, 'A')}
-        it { should have(1).users }
-        its('first.name') { should == 'Auser' }
+        it 'has 1 user' do
+          expect(subject.size).to eq(1)
+        end
+
+        describe '#first' do
+          subject { super().first }
+          describe '#name' do
+            subject { super().name }
+            it { is_expected.to eq('Auser') }
+          end
+        end
       end
       context 'glyph_filter name and empty string' do
         subject { User.glyph_filter(:name, '')}
-        it { should have(27).users }
-        its('first.name') { should == '@user' }
+        it 'has 27 users' do
+          expect(subject.size).to eq(27)
+        end
+
+        describe '#first' do
+          subject { super().first }
+          describe '#name' do
+            subject { super().name }
+            it { is_expected.to eq('@user') }
+          end
+        end
       end
       context 'glyph_filter name and nil' do
         subject { User.glyph_filter(:name, nil)}
-        it { should have(27).users }
-        its('first.name') { should == '@user' }
+        it 'has 27 users' do
+          expect(subject.size).to eq(27)
+        end
+
+        describe '#first' do
+          subject { super().first }
+          describe '#name' do
+            subject { super().name }
+            it { is_expected.to eq('@user') }
+          end
+        end
       end
       context 'glyph_filter name and left_over character' do
         subject { User.glyph_filter(:name, '?')}
-        it { should have(1).users }
-        its('first.name') { should == '@user' }
+        it 'has 1 user' do
+          expect(subject.size).to eq(1)
+        end
+
+        describe '#first' do
+          subject { super().first }
+          describe '#name' do
+            subject { super().name }
+            it { is_expected.to eq('@user') }
+          end
+        end
       end
     end
   end

--- a/spec/models/scopes_spec.rb
+++ b/spec/models/scopes_spec.rb
@@ -28,61 +28,34 @@ describe GlyphFilter::ActiveRecordModelExtension, :type => :model do
     (['@'] + ("A".."Z").to_a).each {|character| User.create! :name => "#{character}user"}
   end
   context "for User" do
-    describe '#glyph_filter' do
+    describe '.glyph_filter' do
+      let(:user_glyph_filter) { User.glyph_filter(*glyph_filter_args) }
       context 'glyph_filter name, A' do
-        subject { User.glyph_filter(:name, 'A')}
-        it 'has 1 user' do
-          expect(subject.size).to eq(1)
-        end
-
-        describe '#first' do
-          subject { super().first }
-          describe '#name' do
-            subject { super().name }
-            it { is_expected.to eq('Auser') }
-          end
+        let(:glyph_filter_args) { [:name, 'A'] }
+        it do
+          expect(user_glyph_filter.size).to eq(1)
+          expect(user_glyph_filter.first.name).to eq 'Auser'
         end
       end
       context 'glyph_filter name and empty string' do
-        subject { User.glyph_filter(:name, '')}
+        let(:glyph_filter_args) { [:name, ''] }
         it 'has 27 users' do
-          expect(subject.size).to eq(27)
-        end
-
-        describe '#first' do
-          subject { super().first }
-          describe '#name' do
-            subject { super().name }
-            it { is_expected.to eq('@user') }
-          end
+          expect(user_glyph_filter.size).to eq(27)
+          expect(user_glyph_filter.first.name).to eq '@user'
         end
       end
       context 'glyph_filter name and nil' do
-        subject { User.glyph_filter(:name, nil)}
+        let(:glyph_filter_args) { [:name, nil] }
         it 'has 27 users' do
-          expect(subject.size).to eq(27)
-        end
-
-        describe '#first' do
-          subject { super().first }
-          describe '#name' do
-            subject { super().name }
-            it { is_expected.to eq('@user') }
-          end
+          expect(user_glyph_filter.size).to eq(27)
+          expect(user_glyph_filter.first.name).to eq '@user'
         end
       end
       context 'glyph_filter name and left_over character' do
-        subject { User.glyph_filter(:name, '?')}
+        let(:glyph_filter_args) { [:name, '?'] }
         it 'has 1 user' do
-          expect(subject.size).to eq(1)
-        end
-
-        describe '#first' do
-          subject { super().first }
-          describe '#name' do
-            subject { super().name }
-            it { is_expected.to eq('@user') }
-          end
+          expect(user_glyph_filter.size).to eq(1)
+          expect(user_glyph_filter.first.name).to eq '@user'
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require 'rails'
 require 'sqlite3'
 require 'glyph_filter'
 require 'database_cleaner'
+require 'action_view'
 require 'haml'
 
 require 'fake_app'
@@ -37,7 +38,6 @@ require 'rspec/rails'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  config.mock_with :rr
   config.before :all do
     CreateAllTables.up unless ActiveRecord::Base.connection.table_exists? 'users'
   end

--- a/spec/support/sqlite_regexp.rb
+++ b/spec/support/sqlite_regexp.rb
@@ -1,0 +1,12 @@
+# user-defined function to add regexp support for sqlite (from wherex gem)
+RSpec.configure do |config|
+  config.before :all do
+    if ::ActiveRecord::Base.connection.raw_connection.respond_to? :create_function
+      ::ActiveRecord::Base.connection.raw_connection.create_function( "regexp", 2 ) do |context, pattern, string|
+        if string.present?
+          context.result = 1 if string.match pattern
+        end
+      end
+    end
+  end
+end

--- a/spec/views/glyph_filter/_all.html_spec.rb
+++ b/spec/views/glyph_filter/_all.html_spec.rb
@@ -23,11 +23,11 @@ IN THE SOFTWARE.
 require 'spec_helper'
 
 [:haml, :erb].each do |template_engine|
-  describe "glyph_filter/_all.html.#{template_engine}" do
+  describe "glyph_filter/_all.html.#{template_engine}", :type => :view do
     it "should render #{template_engine.to_s}" do
-      current_section = stub(:"all?" => true)
+      current_section = double(:"all?" => true)
       url = "https://google.com"
-      lambda { render(:partial => "glyph_filter/all.html", :locals => { :current_section => current_section, :url => url }, :handlers => [template_engine]) }.should_not raise_error
+      expect { render(:partial => "glyph_filter/all.html", :locals => { :current_section => current_section, :url => url }, :handlers => [template_engine]) }.not_to raise_error
     end
   end
 end

--- a/spec/views/glyph_filter/_filter_section.html_spec.rb
+++ b/spec/views/glyph_filter/_filter_section.html_spec.rb
@@ -24,10 +24,10 @@ IN THE SOFTWARE.
 require 'spec_helper'
 
 [:haml, :erb].each do |template_engine|
-  describe "glyph_filter/_filter_section.html.#{template_engine}" do
+  describe "glyph_filter/_filter_section.html.#{template_engine}", :type => :view do
     it "should render #{template_engine.to_s}" do
-      filter_section = stub(:render => '')
-      lambda { render(:partial => "glyph_filter/filter_section.html", :locals => { :filter_section => filter_section }, :handlers => [template_engine]) }.should_not raise_error
+      filter_section = double(:render => '')
+      expect { render(:partial => "glyph_filter/filter_section.html", :locals => { :filter_section => filter_section }, :handlers => [template_engine]) }.not_to raise_error
     end
   end
 end

--- a/spec/views/glyph_filter/_glyph.html_spec.rb
+++ b/spec/views/glyph_filter/_glyph.html_spec.rb
@@ -24,11 +24,11 @@ IN THE SOFTWARE.
 require 'spec_helper'
 
 [:haml, :erb].each do |template_engine|
-  describe "glyph_filter/_glyph.html.#{template_engine}" do
+  describe "glyph_filter/_glyph.html.#{template_engine}", :type => :view do
     it "should render #{template_engine.to_s}" do
-      glyph = stub(:current? => true)
+      glyph = double(:current? => true)
       url = 'https://google.com'
-      lambda { render(:partial => "glyph_filter/glyph.html", :locals => { :glyph => glyph, :url => url }, :handlers => [template_engine]) }.should_not raise_error
+      expect { render(:partial => "glyph_filter/glyph.html", :locals => { :glyph => glyph, :url => url }, :handlers => [template_engine]) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Update to address rails5 deprecation warnings and functionality, including:
- replace alias_method_chain with a module prepend
- update rspec syntax
- remove dependency on defunct `wherex` gem (just use mysql- and sqlite3-compatible `REGEXP` syntax for now)
- fix rails5 url_for unpermitted params (by forcing local-only url generation and permitting the filtered params)
